### PR TITLE
Add Wait Until Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ You can specify chromium/chrome executable with the path. For those who use x86 
 
 > Fortunately, [Raspbian OS](https://www.raspberrypi.org/downloads/raspbian/) (as of ver. April 2019) includes compatible `chromium-browser`, so just set `/usr/bin/chromium-browser` to this blank.
 
+### Wait Until
+
+You can set the event to wait for before taking a screen shot.
+
+- _Load_ - consider navigation to be finished when the `load` event is fired.
+- _DOM Content Loaded_ - consider navigation to be finished when the `DOMContentLoaded` event is fired.
+- _No more than 0 Network Connections for 500ms_ - consider navigation to be finished when there are no more than 0 network connections for at least 500 ms.
+- _No more than 2 Network Connections for 500m_ - consider navigation to be finished when there are no more than 2 network connections for at least 500 ms.
+- _Fixed Delay_ - consider navigation to be finished when timer has elapsed and the `load` devent is fired. Timer value set in the settings in milliseconds. Maximum of 30s.
+
+### [UPDATED]
+
+Add Wait Until setting
+
 ### [UPDATED] Class Name (only in `screenshot-class` node)
 
 For partial screenshots, you can specify a class name of element you want to take screenshots. If blank, a whole screenshot will be taken.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-web-page-screenshot",
-  "version": "0.2.1",
+  "version": "0.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-web-page-screenshot",
-  "version": "0.2.1",
+  "version": "0.2.11",
   "description": "A Node-RED node for taking screenshots of web pages.",
   "main": "screenshot.js",
   "scripts": {

--- a/screenshot-class.html
+++ b/screenshot-class.html
@@ -3,17 +3,25 @@
         category: 'function',
         color: '#c0deed',
         defaults: {
+            delay: {
+                value: 5000,
+                required: false
+            },
+            classname: {
+                value: ''
+            },
             name: {
+                value: ''
+            },
+            path: {
                 value: ''
             },
             url: {
                 value: 'http://www.example.com/'
             },
-            classname: {
-                value: ''
-            },
-            path: {
-                value: ''
+            wait: {
+                value: 'load',
+                required: true
             }
         },
         inputs: 1,
@@ -21,6 +29,23 @@
         icon: 'white-globe.png',
         label: function () {
             return this.name || 'screenshot-class';
+        },
+        oneditprepare: function () {
+            try {
+                var inputWait = $('#node-input-wait');
+                var inputDelay = $('#form-row-delay')
+                inputWait.change(showDelay);
+            } catch (err) {
+                console.error(err);
+            }
+
+            function showDelay() {
+                if (inputWait.val() === 'delay') {
+                    inputDelay.show();
+                } else {
+                    inputDelay.hide();
+                }
+            }
         }
     });
 </script>
@@ -39,11 +64,32 @@
         <input type="text" id="node-input-classname" placeholder="Class Name">
     </div>
     <div class="form-row">
-        <label for="node-input-path">executablePath(optional)</label>
-        <input type="text" id="node-input-path" placeholder="executablePath(optional)">
+        <label for="node-input-wait">Wait Until</label>
+        <select id="node-input-wait" style="width:70%">
+            <option value="load">Load</option>
+            <option value="domcontentloaded">DOM Content Loaded</option>
+            <option value="networkidle0">No more than 0 Network Connections for 500ms</option>
+            <option value="networkidle2">No more than 2 Network Connections for 500ms</option>
+            <option value="delay">Fixed Delay</option>
+        </select>
+    </div>
+    <div class="form-row" id="form-row-delay">
+        <label for="node-input-delay">Delay</label>
+        <input type="number" id="node-input-delay" min="0" step="1" max="30000" placeholder="duration in milliseconds">
     </div>
 </script>
 
 <script type="text/x-red" data-help-name="screenshot-class">
     <p>Take screenshots of a specific class element of web pages.</p>
+    <h3>Inputs</h3>
+        <h4>Wait Until</h4>
+        <p>Wait until an event before taking a screenshot. Defaults to Load.</p>
+        <ul>
+            <li><strong>Load</strong><br><p>consider navigation to be finished when the `load` event is fired.</p></li>
+            <li><strong>DOM Content Loaded</strong><br><p>consider navigation to be finished when the `DOMContentLoaded` event is fired.</p></li>
+            <li><strong>No more than 0 Network Connections for 500ms</strong><br><p>consider navigation to be finished when there are no more than 0 network connections for at least 500 ms.</p></li>
+            <li><strong>No more than 2 Network Connections for 500m</strong><br><p>consider navigation to be finished when there are no more than 2 network connections for at least 500 ms.</p></li>
+            <li><strong>Fixed Delay</strong><br><p>consider navigation to be finished when timer has elapsed and the `load` devent is fired.</p></li>
+        </ul>
+        <p>A maximum duration to wait is 30 seconds by default. See puppeteer documentation <a href="https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagegotourl-options">here</a></p>
 </script>

--- a/screenshot-class.js
+++ b/screenshot-class.js
@@ -33,7 +33,12 @@ module.exports = function (RED) {
                 let option = {};
 
                 const page = await browser.newPage();
-                await page.goto(url);
+                if (config.wait === 'delay') {
+                    await page.goto(url)
+                    await new Promise(resolve => setTimeout(resolve, config.delay));
+                } else {
+                    await page.goto(url, { waitUntil: config.wait });
+                }
 
                 if (className) {
                     const clip = await page.$eval('.' + className, item => {

--- a/screenshot-id.html
+++ b/screenshot-id.html
@@ -3,17 +3,25 @@
         category: 'function',
         color: '#c0deed',
         defaults: {
+            delay: {
+                value: 5000,
+                required: false
+            },
+            idname: {
+                value: ''
+            },
             name: {
+                value: ''
+            },
+            path: {
                 value: ''
             },
             url: {
                 value: 'http://www.example.com/'
             },
-            idname: {
-                value: ''
-            },
-            path: {
-                value: ''
+            wait: {
+                value: 'load',
+                required: true
             }
         },
         inputs: 1,
@@ -21,6 +29,23 @@
         icon: 'white-globe.png',
         label: function () {
             return this.name || 'screenshot-id';
+        },
+        oneditprepare: function () {
+            try {
+                var inputWait = $('#node-input-wait');
+                var inputDelay = $('#form-row-delay')
+                inputWait.change(showDelay);
+            } catch (err) {
+                console.error(err);
+            }
+
+            function showDelay() {
+                if (inputWait.val() === 'delay') {
+                    inputDelay.show();
+                } else {
+                    inputDelay.hide();
+                }
+            }
         }
     });
 </script>
@@ -39,11 +64,32 @@
         <input type="text" id="node-input-idname" placeholder="ID Name">
     </div>
     <div class="form-row">
-        <label for="node-input-path">executablePath(optional)</label>
-        <input type="text" id="node-input-path" placeholder="executablePath(optional)">
+        <label for="node-input-wait">Wait Until</label>
+        <select id="node-input-wait" style="width:70%">
+            <option value="load">Load</option>
+            <option value="domcontentloaded">DOM Content Loaded</option>
+            <option value="networkidle0">No more than 0 Network Connections for 500ms</option>
+            <option value="networkidle2">No more than 2 Network Connections for 500ms</option>
+            <option value="delay">Fixed Delay</option>
+        </select>
+    </div>
+    <div class="form-row" id="form-row-delay">
+        <label for="node-input-delay">Delay</label>
+        <input type="number" id="node-input-delay" min="0" step="1" max="30000" placeholder="duration in milliseconds">
     </div>
 </script>
 
 <script type="text/x-red" data-help-name="screenshot-id">
     <p>Take screenshots of a specific ID element of web pages.</p>
+    <h3>Inputs</h3>
+    <h4>Wait Until</h4>
+    <p>Wait until an event before taking a screenshot. Defaults to Load.</p>
+    <ul>
+        <li><strong>Load</strong><br><p>consider navigation to be finished when the `load` event is fired.</p></li>
+        <li><strong>DOM Content Loaded</strong><br><p>consider navigation to be finished when the `DOMContentLoaded` event is fired.</p></li>
+        <li><strong>No more than 0 Network Connections for 500ms</strong><br><p>consider navigation to be finished when there are no more than 0 network connections for at least 500 ms.</p></li>
+        <li><strong>No more than 2 Network Connections for 500m</strong><br><p>consider navigation to be finished when there are no more than 2 network connections for at least 500 ms.</p></li>
+        <li><strong>Fixed Delay</strong><br><p>consider navigation to be finished when timer has elapsed and the `load` devent is fired.</p></li>
+    </ul>
+    <p>A maximum duration to wait is 30 seconds by default. See puppeteer documentation <a href="https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagegotourl-options">here</a></p>
 </script>

--- a/screenshot-id.js
+++ b/screenshot-id.js
@@ -33,7 +33,12 @@ module.exports = function (RED) {
                 let option = {};
 
                 const page = await browser.newPage();
-                await page.goto(url);
+                if (config.wait === 'delay') {
+                    await page.goto(url)
+                    await new Promise(resolve => setTimeout(resolve, config.delay));
+                } else {
+                    await page.goto(url, { waitUntil: config.wait });
+                }
 
                 if (idName) {
                     const clip = await page.$eval('#' + idName, item => {

--- a/screenshot.html
+++ b/screenshot.html
@@ -3,14 +3,22 @@
         category: 'function',
         color: '#c0deed',
         defaults: {
+            delay: {
+                value: '5000',
+                required: false
+            },
             name: {
                 value: ''
             },
-            url: {
-                value: 'http://www.example.com/'
-            },
             path: {
                 value: ''
+            },
+            wait: {
+                value: 'load',
+                required: true
+            },
+            url: {
+                value: 'http://www.example.com/'
             }
         },
         inputs: 1,
@@ -18,6 +26,23 @@
         icon: 'white-globe.png',
         label: function () {
             return this.name || 'screenshot';
+        },
+        oneditprepare: function () {
+            try {
+                var inputWait = $('#node-input-wait');
+                var inputDelay = $('#form-row-delay')
+                inputWait.change(showDelay);
+            } catch (err) {
+                console.error(err);
+            }
+
+            function showDelay() {
+                if (inputWait.val() === 'delay') {
+                    inputDelay.show();
+                } else {
+                    inputDelay.hide();
+                }
+            }
         }
     });
 </script>
@@ -35,8 +60,33 @@
         <label for="node-input-path">executablePath(optional)</label>
         <input type="text" id="node-input-path" placeholder="executablePath(optional)">
     </div>
+    <div class="form-row">
+        <label for="node-input-wait">Wait Until</label>
+        <select id="node-input-wait" style="width:70%">
+            <option value="load">Load</option>
+            <option value="domcontentloaded">DOM Content Loaded</option>
+            <option value="networkidle0">No more than 0 Network Connections for 500ms</option>
+            <option value="networkidle2">No more than 2 Network Connections for 500ms</option>
+            <option value="delay">Fixed Delay</option>
+        </select>
+    </div>
+    <div class="form-row" id="form-row-delay">
+        <label for="node-input-delay">Delay</label>
+        <input type="number" id="node-input-delay" min="0" step="1" max="30000" placeholder="duration in milliseconds">
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="screenshot">
     <p>Take screenshots of web pages.</p>
+    <h3>Inputs</h3>
+        <h4>Wait Until</h4>
+        <p>Wait until an event before taking a screenshot. Defaults to Load.</p>
+        <ul>
+            <li><strong>Load</strong><br><p>consider navigation to be finished when the `load` event is fired.</p></li>
+            <li><strong>DOM Content Loaded</strong><br><p>consider navigation to be finished when the `DOMContentLoaded` event is fired.</p></li>
+            <li><strong>No more than 0 Network Connections for 500ms</strong><br><p>consider navigation to be finished when there are no more than 0 network connections for at least 500 ms.</p></li>
+            <li><strong>No more than 2 Network Connections for 500m</strong><br><p>consider navigation to be finished when there are no more than 2 network connections for at least 500 ms.</p></li>
+            <li><strong>Fixed Delay</strong><br><p>consider navigation to be finished when timer has elapsed and the `load` devent is fired.</p></li>
+        </ul>
+        <p>A maximum duration to wait is 30 seconds by default. See puppeteer documentation <a href="https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagegotourl-options">here</a></p>
 </script>

--- a/screenshot.js
+++ b/screenshot.js
@@ -29,7 +29,12 @@ module.exports = function (RED) {
                     encoding: 'base64'
                 };
                 const page = await browser.newPage();
-                await page.goto(url);
+                if (config.wait === 'delay') {
+                    await page.goto(url)
+                    await new Promise(resolve => setTimeout(resolve, config.delay));
+                } else {
+                    await page.goto(url, { waitUntil: config.wait });
+                }
                 const base64String = await page.screenshot(option);
                 await browser.close();
 


### PR DESCRIPTION
Expose Puppeteer's `waitUntil` option on [page.goto(url, options))](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagegotourl-options).
Included an additional fixed delay timer option.
Updated node documentation.
Updated Readme
Bumped revision